### PR TITLE
Fix delay and publish diagnostic

### DIFF
--- a/include/usb_cam/usb_cam_node.hpp
+++ b/include/usb_cam/usb_cam_node.hpp
@@ -36,6 +36,8 @@
 #include <vector>
 
 #include "camera_info_manager/camera_info_manager.hpp"
+#include "diagnostic_updater/diagnostic_updater.hpp"
+#include "diagnostic_updater/publisher.hpp"
 #include "image_transport/image_transport.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"
@@ -96,6 +98,10 @@ public:
 
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr m_service_capture;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr m_parameters_callback_handle;
+
+  diagnostic_updater::Updater m_updater;
+  std::shared_ptr<diagnostic_updater::TopicDiagnostic> m_topic_diagnostic;
+  double m_topic_frequency;
 };
 }  // namespace usb_cam
 #endif  // USB_CAM__USB_CAM_NODE_HPP_

--- a/include/usb_cam/usb_cam_node.hpp
+++ b/include/usb_cam/usb_cam_node.hpp
@@ -66,6 +66,7 @@ public:
   void assign_params(const std::vector<rclcpp::Parameter> & parameters);
   void set_v4l2_params();
   void update();
+  void publish();
   bool take_and_send_image();
   bool take_and_send_image_mjpeg();
 
@@ -91,6 +92,7 @@ public:
   std::shared_ptr<camera_info_manager::CameraInfoManager> m_camera_info;
 
   rclcpp::TimerBase::SharedPtr m_timer;
+  rclcpp::TimerBase::SharedPtr m_publish_timer;
 
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr m_service_capture;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr m_parameters_callback_handle;

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <depend>rclcpp_components</depend>
 
   <depend>cv_bridge</depend>
+  <depend>diagnostic_updater</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>sensor_msgs</depend>

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -524,7 +524,7 @@ void UsbCam::configure(
   m_image.pixel_format = set_pixel_format(parameters);
   m_image.set_bytes_per_line();
   m_image.set_size_in_bytes();
-  m_framerate = parameters.framerate;
+  m_framerate = set_frame_rate(parameters);
 
   init_device();
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

When receiving camera images via V4L,
it is unclear whether images accumulate in the buffer,
but if the framerate parameter is set lower than the default, the usb_cam node retrieves old images, causing noticeable delay.

To address this, image acquisition from V4L now runs at the default rate, while only the ROS2 topic publishing rate is adjusted via the framerate parameter.

And publish topic diagnostic

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- ref https://github.com/sbgisen/soar/issues/658

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
